### PR TITLE
refactor: add env key validation and more cleanups

### DIFF
--- a/error-listener.js
+++ b/error-listener.js
@@ -61,7 +61,7 @@ async function getPackageManager() {
   if (!openaiApiKey) {
     console.error(
       chalk.yellow(
-        '\nError: "OPENAI_API_KEY" environment variable not set! Please set it to your .env file.\n'
+        '\nError: "OPENAI_API_KEY" environment variable is not set! Please set it in your .env file.\n'
       )
     );
     process.exit(1);

--- a/src/error-analyzer.js
+++ b/src/error-analyzer.js
@@ -1,12 +1,8 @@
 import fetch from "node-fetch";
-import dotenv from "dotenv";
 
-dotenv.config();
-
-const openaiApiKey = process.env.OPENAI_API_KEY;
 const OPENAI_ENDPOINT = "https://api.openai.com/v1/completions";
 
-async function handleErrors(logData, projectType) {
+async function handleErrors(logData, projectType = "generic", openaiApiKey) {
   const errorPatterns = {
     next: /Error:([\s\S]+?)\n\n/,
     react: /Error:([\s\S]+?)\n\n/,


### PR DESCRIPTION
- Add validation for `OPENAI_API_KEY` environment variable. It will show an error and exit the process if no API key is present.
- Remove redundant duplicate logs. This is because `npm-copilot` outputs the stdout/stderr twice which is not needed imo and makes the logs more cluttered.

![image](https://user-images.githubusercontent.com/33410545/230561687-2253141a-29e9-408d-a92a-0ac84c1d6a55.png)