### PR TITLE
refactor: make file checking less expensive

### DIFF
--- a/error-listener.js
+++ b/error-listener.js
@@ -41,12 +41,15 @@ async function getProjectType() {
 }
 
 async function getPackageManager() {
+  const yarnLockPath = path.join(process.cwd(), "yarn.lock");
+  const pnpmLockPath = path.join(process.cwd(), "pnpm-lock.yaml");
+
   try {
-    await fs.readFile(path.join(process.cwd(), "yarn.lock"), "utf8");
+    await fs.access(yarnLockPath, fs.constants.F_OK);
     return "yarn";
   } catch (error) {
     try {
-      await fs.readFile(path.join(process.cwd(), "pnpm-lock.yaml"), "utf8");
+      await fs.access(pnpmLockPath, fs.constants.F_OK);
       return "pnpm";
     } catch (error) {
       return "npm";


### PR DESCRIPTION
`fs.readFile` is a very expensive way to check for file existence. It loads the entire file contents into memory. This can be a heavy operation, especially if the file is large. And generally the `*.lock` files are of large sizes.

So switched to `fs.access` which only checks if the file exists and does not retrieve any information. Thus less expensive and much faster.

> I ran a small benchmark. You can see the difference in speed of these methods are massive.

```zsh
benchmark         time (avg)             (min … max)       p75       p99      p995
---------------------------------------------------- -----------------------------
• "yarn.lock" file
---------------------------------------------------- -----------------------------
fs.readFiile  486.87 µs/iter   (320.48 µs … 1.98 ms) 438.97 µs   1.29 ms   1.46 ms
fs.access       1.66 µs/iter      (1.6 µs … 1.84 µs)   1.69 µs   1.84 µs   1.84 µs

summary for "yarn.lock" file
  fs.access
   292.59x faster than fs.readFiile
```